### PR TITLE
Make NBCHelperAuthorization code more extensible.

### DIFF
--- a/NBICreator/Helper/NBCHelper.m
+++ b/NBICreator/Helper/NBCHelper.m
@@ -163,19 +163,19 @@ static const NSTimeInterval kHelperCheckInterval = 1.0;
 ////////////////////////////////////////////////////////////////////////////////
 
 - (void)authorizeWorkflowCasper:(NSData *)authData withReply:(void(^)(NSError *error))reply {
-    reply([NBCHelperAuthorization authorizeWorkflowCasper:authData]);
+    reply([NBCHelperAuthorization authorizeWorkflow:NBCAuthorizationRightWorkflowCasper authData:authData]);
 } // authorizeWorkflowCasper:withReply
 
 - (void)authorizeWorkflowDeployStudio:(NSData *)authData withReply:(void(^)(NSError *error))reply {
-    reply([NBCHelperAuthorization authorizeWorkflowDeployStudio:authData]);
+    reply([NBCHelperAuthorization authorizeWorkflow:NBCAuthorizationRightWorkflowDeployStudio authData:authData]);
 } // authorizeWorkflowDeployStudio:withReply
 
 - (void)authorizeWorkflowImagr:(NSData *)authData withReply:(void(^)(NSError *error))reply {
-    reply([NBCHelperAuthorization authorizeWorkflowImagr:authData]);
+    reply([NBCHelperAuthorization authorizeWorkflow:NBCAuthorizationRightWorkflowImagr authData:authData]);
 } // authorizeWorkflowImagr:withReply
 
 - (void)authorizeWorkflowNetInstall:(NSData *)authData withReply:(void(^)(NSError *error))reply {
-    reply([NBCHelperAuthorization authorizeWorkflowNetInstall:authData]);
+    reply([NBCHelperAuthorization authorizeWorkflow:NBCAuthorizationRightWorkflowNetInstall authData:authData]);
 } // authorizeWorkflowNetInstall:withReply
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/NBICreator/Helper/NBCHelperAuthorization.h
+++ b/NBICreator/Helper/NBCHelperAuthorization.h
@@ -21,13 +21,8 @@
 
 @interface NBCHelperAuthorization : NSObject
 
-+ (NSError *)authorizeWorkflowCasper:(NSData *)authData;
-+ (NSError *)authorizeWorkflowDeployStudio:(NSData *)authData;
-+ (NSError *)authorizeWorkflowImagr:(NSData *)authData;
-+ (NSError *)authorizeWorkflowNetInstall:(NSData *)authData;
-
++ (NSError *)authorizeWorkflow:(NSString *)workflowId authData:(NSData *)authData;
 + (NSError *)checkAuthorization:(NSData *)authData command:(SEL)command;
-
 + (NSData *)authorizeHelper;
 
 @end


### PR DESCRIPTION
This cleans up some code duplication and should make it easier to include new rights as they're needed. 

Now there's a single utility method

``` Objective-c
+ (NSError *)authorizeWorkflow:(NSString *)workflowId authData:(NSData *)authData
```

And you can update the necessary rights by modifying the array of right's names in 

``` Objective-c
+ (NSDictionary *)authRightsDictionary
```
